### PR TITLE
Renamed from escape to quote

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -283,9 +283,9 @@ func TestDB_Import(t *testing.T) {
 	}
 }
 
-func TestDB_EscapeName(t *testing.T) {
+func TestDB_QuotedName(t *testing.T) {
 	type fields struct {
-		escape string
+		quote string
 	}
 	type args struct {
 		oldName string
@@ -298,19 +298,19 @@ func TestDB_EscapeName(t *testing.T) {
 	}{
 		{
 			name:   "test1",
-			fields: fields{escape: "`"},
+			fields: fields{quote: "`"},
 			args:   args{oldName: "test"},
 			want:   "`test`",
 		},
 		{
 			name:   "test2",
-			fields: fields{escape: "\""},
+			fields: fields{quote: "\""},
 			args:   args{oldName: "test"},
 			want:   "\"test\"",
 		},
 		{
 			name:   "test3",
-			fields: fields{escape: "`"},
+			fields: fields{quote: "`"},
 			args:   args{oldName: "`test`"},
 			want:   "`test`",
 		},
@@ -318,10 +318,10 @@ func TestDB_EscapeName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := &DB{
-				escape: tt.fields.escape,
+				quote: tt.fields.quote,
 			}
-			if got := db.EscapeName(tt.args.oldName); got != tt.want {
-				t.Errorf("DB.EscapeName() = %v, want %v", got, tt.want)
+			if got := db.QuotedName(tt.args.oldName); got != tt.want {
+				t.Errorf("DB.QuotedName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/importer.go
+++ b/importer.go
@@ -162,7 +162,7 @@ func isSQLKeyWords(str string) bool {
 }
 
 // ImportFile is imports a file.
-// Return the escaped table name and error.
+// Return the quoted table name and error.
 // Do not import if file not found (no error).
 // Wildcards can be passed as fileName.
 func ImportFile(db *DB, fileName string, readOpts *ReadOpts) (string, error) {
@@ -187,7 +187,7 @@ func ImportFile(db *DB, fileName string, readOpts *ReadOpts) (string, error) {
 		return "", err
 	}
 
-	tableName := db.EscapeName(fileName)
+	tableName := db.QuotedName(fileName)
 	columnNames, err := reader.Names()
 	if err != nil {
 		if err != io.EOF {


### PR DESCRIPTION
Quote is preferred because it is a quoted character.
Change EscapeName to QuotedName and call it from others.