### PR TITLE
Improved output of columns with line breaks

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -94,7 +93,6 @@ func ValString(v interface{}) string {
 		}
 	default:
 		str = fmt.Sprint(v)
-		str = strings.ReplaceAll(str, "\n", "\\n")
 	}
 	return str
 }

--- a/output_tbln.go
+++ b/output_tbln.go
@@ -41,7 +41,8 @@ func (w *TBLNWriter) PreWrite(columns []string, types []string) error {
 // WriteRow is row write.
 func (w *TBLNWriter) WriteRow(values []interface{}, columns []string) error {
 	for i, col := range values {
-		w.results[i] = ValString(col)
+		str := ValString(col)
+		w.results[i] = strings.ReplaceAll(str, "\n", "\\n")
 	}
 	return w.writer.WriteRow(w.results)
 }


### PR DESCRIPTION
The column containing '\n' was replaced with '\\n'.
However, replacing all the output is not the desired result
(especially raw output), so change it to tbln output only.