### PR TITLE
Change TrimLeadingSpace set conditions (Fix #84).

### DIFF
--- a/input_csv.go
+++ b/input_csv.go
@@ -23,8 +23,14 @@ func NewCSVReader(reader io.Reader, opts *ReadOpts) (*CSVReader, error) {
 	r.reader = csv.NewReader(reader)
 	r.reader.LazyQuotes = true
 	r.reader.FieldsPerRecord = -1 // no check count
-	r.reader.TrimLeadingSpace = true
+
 	r.reader.Comma, err = delimiter(opts.InDelimiter)
+	if err != nil {
+		return nil, err
+	}
+	if opts.InDelimiter == " " {
+		r.reader.TrimLeadingSpace = true
+	}
 
 	if opts.InSkip > 0 {
 		skip := make([]interface{}, 1)

--- a/input_csv_test.go
+++ b/input_csv_test.go
@@ -87,17 +87,20 @@ func TestCsvEmptyColumnRowNew(t *testing.T) {
 	ro.InHeader = true
 	ro.InDelimiter = ","
 	csvStream := `h1,h2
-	,v2`
+,v2`
 	s := strings.NewReader(csvStream)
-	r, _ := NewCSVReader(s, ro)
-	_, err := r.Names()
+	r, err := NewCSVReader(s, ro)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = r.Names()
 	if err != nil {
 		t.Error(err)
 	}
 	record := make([]interface{}, 2)
 	record, _ = r.ReadRow(record)
 	if record[0] != "" || record[1] != "v2" {
-		t.Error("invalid value")
+		t.Errorf("invalid value [%s,%s]", record[0], record[1])
 	}
 }
 


### PR DESCRIPTION
Stop setting TrimLeadingSpace = true when the delimiter is not space.
Setting TrimLeadingSpace to true removes unicode.IsSpace as well as space.
This is not the intended behavior.