### PR TITLE
revert the checking regular expression.

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/logrusorgru/aurora"
@@ -118,10 +119,14 @@ func examples(tableName string, names []string, results []string) []string {
 	return queries
 }
 
+var noQuoteRegexp = regexp.MustCompile(`^[a-z0-9_]+$`)
+
 func quoted(name string, quote string) string {
-	_, exist := keywords[name]
-	if exist {
-		return quote + name + quote
+	if noQuoteRegexp.MatchString(name) {
+		_, exist := keywords[name]
+		if !exist {
+			return name
+		}
 	}
-	return name
+	return quote + name + quote
 }


### PR DESCRIPTION
Regular expressions had to check only lowercase letters, _, and numbers,
and also reserved words.