### PR TITLE
Fixed generate_series (1,10) error in FROM clause

### DIFF
--- a/importer.go
+++ b/importer.go
@@ -56,6 +56,7 @@ func (i *ReadFormat) Import(db *DB, query string) (string, error) {
 		debug.Printf("table not found\n")
 		return query, nil
 	}
+
 	for fileName := range tables {
 		tableName, err := ImportFile(db, fileName, i.ReadOpts)
 		if err != nil {
@@ -68,7 +69,9 @@ func (i *ReadFormat) Import(db *DB, query string) (string, error) {
 
 	// replace table names in query with their quoted values
 	for _, idx := range tableIdx {
-		parsedQuery[idx] = tables[parsedQuery[idx]]
+		if table, ok := tables[parsedQuery[idx]]; ok {
+			parsedQuery[idx] = table
+		}
 	}
 
 	// reconstruct the query with quoted table names

--- a/importer_test.go
+++ b/importer_test.go
@@ -55,6 +55,20 @@ func TestImporter_Import(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "testGenerate_series",
+			fields:  fields{ReadOpts: NewReadOpts()},
+			query:   "SELECT * FROM generate_series(1,10)",
+			want:    "SELECT * FROM generate_series(1,10)",
+			wantErr: false,
+		},
+		{
+			name:    "testGenerate_series2",
+			fields:  fields{ReadOpts: NewReadOpts()},
+			query:   "SELECT * FROM generate_series(1,10,2)",
+			want:    "SELECT * FROM generate_series(1,10,2)",
+			wantErr: false,
+		},
+		{
 			name:    "test3",
 			fields:  fields{ReadOpts: NewReadOpts(InDelimiter("ddd"))},
 			query:   "SELECT * FROM testdata/test.csv",


### PR DESCRIPTION
Added check for table name not in list to replace.
Tables that did not successfully import the file
did not need to be replaced in the first place.