### PR TITLE
Added option to quote all columns with quotes(#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ trdsql [options] SQL
         Output column name as header.
 * `-od` **delimiter character**
         Field delimiter for output. (default ",")
+* `-oq`
+        Quote character for output. (default "\"")
+* `-oaq`
+        Enclose all fields in quotes for output.
+* `-ocrlf`
+        Use CRLF for output.
+
 
 ##  4. <a name='Example'></a>Example
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -145,7 +145,7 @@ func (cli Cli) Run(args []string) int {
 
 	flags.StringVar(&outDelimiter, "od", ",", "Field delimiter for output.")
 	flags.StringVar(&outQuote, "oq", "\"", "Quote character for output.")
-	flags.BoolVar(&outAllQuotes, "oaq", false, "Enclose all fields in quotes for for output.")
+	flags.BoolVar(&outAllQuotes, "oaq", false, "Enclose all fields in quotes for output.")
 	flags.BoolVar(&outUseCRLF, "ocrlf", false, "Use CRLF for output.")
 	flags.BoolVar(&outHeader, "oh", false, "Output column name as header.")
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -112,6 +112,9 @@ func (cli Cli) Run(args []string) int {
 
 		outFlag      outputFlag
 		outDelimiter string
+		outQuote     string
+		outAllQuotes bool
+		outUseCRLF   bool
 		outHeader    bool
 	)
 
@@ -141,6 +144,9 @@ func (cli Cli) Run(args []string) int {
 	flags.BoolVar(&inFlag.TBLN, "itbln", false, "TBLN format for input.")
 
 	flags.StringVar(&outDelimiter, "od", ",", "Field delimiter for output.")
+	flags.StringVar(&outQuote, "oq", "\"", "Quote character for output.")
+	flags.BoolVar(&outAllQuotes, "oaq", false, "Enclose all fields in quotes for for output.")
+	flags.BoolVar(&outUseCRLF, "ocrlf", false, "Use CRLF for output.")
 	flags.BoolVar(&outHeader, "oh", false, "Output column name as header.")
 
 	flags.BoolVar(&outFlag.CSV, "ocsv", true, "CSV format for output.")
@@ -233,6 +239,9 @@ Options:
 	w := trdsql.NewWriter(
 		trdsql.OutFormat(outputFormat(outFlag)),
 		trdsql.OutDelimiter(outDelimiter),
+		trdsql.OutQuote(outQuote),
+		trdsql.OutAllQuotes(outAllQuotes),
+		trdsql.OutUseCRLF(outUseCRLF),
 		trdsql.OutHeader(outHeader),
 		trdsql.OutStream(cli.OutStream),
 		trdsql.ErrStream(cli.ErrStream),

--- a/completion/trdsql-completion.zsh
+++ b/completion/trdsql-completion.zsh
@@ -22,7 +22,7 @@ function _trdsql {
     '-ir[umber of row preread for column determination.(default 1)]::' \
     '-od[Field delimiter for output. (default ",")]' \
     '-oq[Quote character for output. (default "\"")]' \
-    '-oaq[Enclose all fields in quotes for for output.]' \
+    '-oaq[Enclose all fields in quotes for output.]' \
     '-ocrlf[Use CRLF for output.]' \
     '-oh[Output column name as header.]' \
     '-oat[ASCII Table format for output.]' \

--- a/completion/trdsql-completion.zsh
+++ b/completion/trdsql-completion.zsh
@@ -21,6 +21,9 @@ function _trdsql {
     '-is[Skip header row.]::' \
     '-ir[umber of row preread for column determination.(default 1)]::' \
     '-od[Field delimiter for output. (default ",")]' \
+    '-oq[Quote character for output. (default "\"")]' \
+    '-oaq[Enclose all fields in quotes for for output.]' \
+    '-ocrlf[Use CRLF for output.]' \
     '-oh[Output column name as header.]' \
     '-oat[ASCII Table format for output.]' \
     '-ojson[JSON format for output.]' \

--- a/database.go
+++ b/database.go
@@ -50,14 +50,17 @@ type DB struct {
 // Currently supported drivers are sqlite3, mysql, postgres.
 // Set quote character and maxBulk depending on the driver type.
 func Connect(driver, dsn string) (*DB, error) {
-	var db DB
 	var err error
+
+	db := &DB{}
 	db.DB, err = sql.Open(driver, dsn)
 	if err != nil {
 		return nil, err
 	}
 	db.driver = driver
 	db.dsn = dsn
+	debug.Printf("driver: %s, dsn: %s", driver, dsn)
+
 	switch driver {
 	case "sqlite3":
 		db.quote = "`"
@@ -68,8 +71,8 @@ func Connect(driver, dsn string) (*DB, error) {
 	case "postgres":
 		db.quote = "\""
 	}
-	debug.Printf("driver: %s, dsn: %s", driver, dsn)
-	return &db, nil
+
+	return db, nil
 }
 
 // Disconnect is disconnect the database.
@@ -196,6 +199,7 @@ func (db *DB) copyImport(table *Table, reader Reader) error {
 func (db *DB) insertImport(table *Table, reader Reader) error {
 	var err error
 	var stmt *sql.Stmt
+
 	defer db.stmtClose(stmt)
 
 	// #nosec G202

--- a/database.go
+++ b/database.go
@@ -153,6 +153,7 @@ func (db *DB) copyImport(table *Table, reader Reader) error {
 	if err != nil {
 		return fmt.Errorf("copy prepare: %s", err)
 	}
+	defer db.stmtClose(stmt)
 
 	preReadRows := reader.PreReadRow()
 	for _, row := range preReadRows {
@@ -187,7 +188,7 @@ func (db *DB) copyImport(table *Table, reader Reader) error {
 		return err
 	}
 
-	return stmt.Close()
+	return nil
 }
 
 // insertImport adds a row to a table with an INSERT clause.
@@ -247,11 +248,11 @@ func (db *DB) insertImport(table *Table, reader Reader) error {
 }
 
 func (db *DB) stmtClose(stmt *sql.Stmt) {
-	if stmt != nil {
-		err := stmt.Close()
-		if err != nil {
-			log.Printf("ERROR: stmtClose:%s", err)
-		}
+	if stmt == nil {
+		return
+	}
+	if err := stmt.Close(); err != nil {
+		log.Printf("ERROR: stmtClose:%s", err)
 	}
 }
 

--- a/exporter.go
+++ b/exporter.go
@@ -88,9 +88,8 @@ func ValString(v interface{}) string {
 	case []byte:
 		if ok := utf8.Valid(t); ok {
 			return string(t)
-		} else {
-			return `\x` + hex.EncodeToString(t)
 		}
+		return `\x` + hex.EncodeToString(t)
 	case int:
 		return strconv.Itoa(t)
 	case int32:

--- a/output_csv.go
+++ b/output_csv.go
@@ -1,44 +1,134 @@
 package trdsql
 
 import (
-	"encoding/csv"
+	"bufio"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // CSVWriter provides methods of the Writer interface.
 type CSVWriter struct {
-	writer    *csv.Writer
-	results   []string
-	outHeader bool
+	writer       *bufio.Writer
+	outHeader    bool
+	outDelimiter rune
+	outQuote     rune
+	outAllQuote  bool
+	outUseCRLF   bool
+	needQuotes   string
+	endLine      string
 }
 
 // NewCSVWriter returns CSVWriter.
 func NewCSVWriter(writeOpts *WriteOpts) *CSVWriter {
 	var err error
 	w := &CSVWriter{}
-	w.writer = csv.NewWriter(writeOpts.OutStream)
-	w.writer.Comma, err = delimiter(writeOpts.OutDelimiter)
+	w.writer = bufio.NewWriter(writeOpts.OutStream)
+	w.outDelimiter, err = delimiter(writeOpts.OutDelimiter)
 	if err != nil {
 		debug.Printf("%s\n", err)
 	}
+	if len(writeOpts.OutQuote) > 0 {
+		w.outQuote = ([]rune(writeOpts.OutQuote))[0]
+	} else {
+		w.outQuote = 0
+	}
+	w.outAllQuote = writeOpts.OutAllQuotes
+	w.outUseCRLF = writeOpts.OutUseCRLF
 	w.outHeader = writeOpts.OutHeader
+	w.needQuotes = string(w.outDelimiter) + string(w.outQuote) + "\r\n"
+	if writeOpts.OutUseCRLF {
+		w.endLine = "\r\n"
+	} else {
+		w.endLine = "\n"
+	}
 	return w
 }
 
 // PreWrite is output of header and preparation.
 func (w *CSVWriter) PreWrite(columns []string, types []string) error {
-	w.results = make([]string, len(columns))
+	var err error
 	if w.outHeader {
-		return w.writer.Write(columns)
+		for n, column := range columns {
+			if n > 0 {
+				if _, err = w.writer.WriteRune(w.outDelimiter); err != nil {
+					return err
+				}
+			}
+			if err = w.writeColumn(column); err != nil {
+				return err
+			}
+		}
+		_, err = w.writer.WriteString(w.endLine)
+		return err
 	}
 	return nil
 }
 
 // WriteRow is row write.
 func (w *CSVWriter) WriteRow(values []interface{}, columns []string) error {
-	for i, col := range values {
-		w.results[i] = ValString(col)
+	var err error
+	for n, field := range values {
+		if n > 0 {
+			if _, err = w.writer.WriteRune(w.outDelimiter); err != nil {
+				return err
+			}
+		}
+		if err = w.writeColumn(ValString(field)); err != nil {
+			return err
+		}
 	}
-	return w.writer.Write(w.results)
+	_, err = w.writer.WriteString(w.endLine)
+	return err
+}
+
+func (w *CSVWriter) writeColumn(column string) error {
+	if !w.fieldNeedsQuotes(column) {
+		_, err := w.writer.WriteString(column)
+		return err
+	}
+
+	if _, err := w.writer.WriteRune(w.outQuote); err != nil {
+		return err
+	}
+	var err error
+	for _, r1 := range column {
+		switch r1 {
+		case w.outQuote:
+			_, err = w.writer.WriteString(string([]rune{w.outQuote, w.outQuote}))
+		case '\r':
+			if !w.outUseCRLF {
+				err = w.writer.WriteByte('\r')
+			}
+		case '\n':
+			if w.outUseCRLF {
+				_, err = w.writer.WriteString("\r\n")
+			} else {
+				err = w.writer.WriteByte('\n')
+			}
+		default:
+			_, err = w.writer.WriteRune(r1)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	_, err = w.writer.WriteRune(w.outQuote)
+	return err
+}
+
+func (w *CSVWriter) fieldNeedsQuotes(field string) bool {
+	if w.outAllQuote {
+		return true
+	}
+	if field == "" {
+		return false
+	}
+	if field == `\.` || strings.ContainsAny(field, w.needQuotes) {
+		return true
+	}
+	r1, _ := utf8.DecodeRuneInString(field)
+	return unicode.IsSpace(r1)
 }
 
 // PostWrite is flush.

--- a/output_csv_test.go
+++ b/output_csv_test.go
@@ -40,8 +40,8 @@ func TestNewCSVWriter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewCSVWriter(tt.args.writeOpts)
-			if !reflect.DeepEqual(got.writer.Comma, tt.want) {
-				t.Errorf("NewCSVWriter() = %v, want %v", got.writer.Comma, tt.want)
+			if !reflect.DeepEqual(got.outDelimiter, tt.want) {
+				t.Errorf("NewCSVWriter() = %v, want %v", got.outDelimiter, tt.want)
 			}
 		})
 	}
@@ -103,9 +103,6 @@ func TestCSVWriter_PreWrite(t *testing.T) {
 			w := NewCSVWriter(&tt.writeOpts)
 			if err := w.PreWrite(tt.args.columns, tt.args.types); (err != nil) != tt.wantErr {
 				t.Errorf("CSVWriter.PreWrite() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !reflect.DeepEqual(w.results, tt.want) {
-				t.Errorf("CSVWriter.PreWrite() error = %v, want %v", w.results, tt.want)
 			}
 		})
 	}

--- a/testdata/test_quote.csv
+++ b/testdata/test_quote.csv
@@ -1,0 +1,3 @@
+1,O"range
+2,M'elon
+3,A pple

--- a/testdata/test_quote2.csv
+++ b/testdata/test_quote2.csv
@@ -1,0 +1,5 @@
+1,"O""range"
+2,"M'elon"
+3,"A pple"
+4,"ba
+nana"

--- a/trdsql_test.go
+++ b/trdsql_test.go
@@ -236,7 +236,6 @@ func TestTRDSQL_ErrDBExec(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestTRDSQL_ErrWrite(t *testing.T) {

--- a/writer.go
+++ b/writer.go
@@ -21,6 +21,15 @@ type WriteOpts struct {
 	// OutDelimiter is the output delimiter (Use only CSV and Raw).
 	OutDelimiter string
 
+	// OutQuote is the output quote character (Use only CSV).
+	OutQuote string
+
+	// OutAllQuotes is true if Enclose all fields (Use only CSV).
+	OutAllQuotes bool
+
+	// True to use \r\n as the line terminator (Use only CSV).
+	OutUseCRLF bool
+
 	// OutHeader is true if it outputs a header(Use only CSV and Raw).
 	OutHeader bool
 
@@ -45,6 +54,27 @@ func OutFormat(f Format) WriteOpt {
 func OutDelimiter(d string) WriteOpt {
 	return func(args *WriteOpts) {
 		args.OutDelimiter = d
+	}
+}
+
+// OutQuote sets quote.
+func OutQuote(q string) WriteOpt {
+	return func(args *WriteOpts) {
+		args.OutQuote = q
+	}
+}
+
+// OutUseCRLF sets use CRLF.
+func OutUseCRLF(c bool) WriteOpt {
+	return func(args *WriteOpts) {
+		args.OutUseCRLF = c
+	}
+}
+
+// OutAllQuotes sets all quotes.
+func OutAllQuotes(a bool) WriteOpt {
+	return func(args *WriteOpts) {
+		args.OutAllQuotes = a
 	}
 }
 
@@ -82,6 +112,9 @@ func NewWriter(options ...WriteOpt) Writer {
 	writeOpts := &WriteOpts{
 		OutFormat:    CSV,
 		OutDelimiter: ",",
+		OutQuote:     "\"",
+		OutAllQuotes: false,
+		OutUseCRLF:   false,
 		OutHeader:    false,
 		OutStream:    os.Stdout,
 		ErrStream:    os.Stderr,

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,15 @@
+package trdsql
+
+import "errors"
+
+type errorWriter struct{}
+
+func (e errorWriter) PreWrite([]string, []string) error {
+	return nil
+}
+func (e errorWriter) WriteRow([]interface{}, []string) error {
+	return errors.New("Test")
+}
+func (e errorWriter) PostWrite() error {
+	return nil
+}


### PR DESCRIPTION
Remove use of encoding/csv, and output CSV in writer.
Added option to specify quote character.
Option to set CRLF at the end of line.
CSV output performance has been improved.