### PR TITLE
Added Context support

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"compress/gzip"
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -231,6 +232,8 @@ func (cli Cli) Run(args []string) int {
 		return 0
 	}
 
+	ctx := context.Background()
+
 	query, err := getQuery(flags.Args(), queryFile)
 	if err != nil {
 		log.Printf("ERROR: %s", err)
@@ -242,7 +245,8 @@ func (cli Cli) Run(args []string) int {
 		return 2
 	}
 
-	importer := trdsql.NewImporter(
+	importer := trdsql.NewImporterContext(
+		ctx,
 		trdsql.InFormat(inputFormat(inFlag)),
 		trdsql.InDelimiter(inDelimiter),
 		trdsql.InHeader(inHeader),
@@ -289,9 +293,9 @@ func (cli Cli) Run(args []string) int {
 		trdsql.OutStream(writer),
 		trdsql.ErrStream(cli.ErrStream),
 	)
-	exporter := trdsql.NewExporter(w)
+	exporter := trdsql.NewExporterContext(ctx, w)
 
-	trd := trdsql.NewTRDSQL(importer, exporter)
+	trd := trdsql.NewTRDSQLContext(ctx, importer, exporter)
 
 	if driver != "" {
 		trd.Driver = driver

--- a/writer.go
+++ b/writer.go
@@ -1,6 +1,7 @@
 package trdsql
 
 import (
+	"context"
 	"io"
 	"os"
 )
@@ -35,12 +36,13 @@ type WriteOpts struct {
 
 	// OutNoWrap is true, do not wrap long columns(Use only AT and MD).
 	OutNoWrap bool
-
 	// OutStream is the output destination.
 	OutStream io.Writer
 
 	// ErrStream is the error output destination.
 	ErrStream io.Writer
+
+	ctx context.Context
 }
 
 // WriteOpt is a function to set WriteOpts.
@@ -128,6 +130,7 @@ func NewWriter(options ...WriteOpt) Writer {
 		OutHeader:    false,
 		OutStream:    os.Stdout,
 		ErrStream:    os.Stderr,
+		ctx:          context.Background(),
 	}
 	for _, option := range options {
 		option(writeOpts)


### PR DESCRIPTION
* Changed the query to database to use with context.
* Functions with Context are added to NewTRDSQL, NewImporter
  and NewExporter.
* Changed public Table struct to private importTable struct.
* Stopped running db.stmtClose with defer.
  Since it is not canceled at context.Cancel, it is closed only
  when it is normal.