### PR TITLE
README: fix the option value of "docker run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ docker build -t trdsql .
 Docker run.
 
 ```console
-docker run --rm -it -v $(pwd)/tmp trdsql [options and commands]
+docker run --rm -it -v $(pwd):/tmp trdsql [options and commands]
 ```
 
 ##  3. <a name='Usage'></a>Usage


### PR DESCRIPTION
## About

- The `-v` option needs to separator (`:`)
