### PR TITLE
Fixed JSON sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Please use SQL function.
 * [MySQL - Functions That Search JSON Values](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html)
 
 ```console
-$ trdsql -ijson "SELECT id, name, JSON_EXTRACT(attribute,'$country'), JSON_EXTRACT(attribute,'$color') FROM sample2.json"
+$ trdsql -ijson "SELECT id, name, JSON_EXTRACT(attribute,'$.country'), JSON_EXTRACT(attribute,'$.color') FROM sample2.json"
 1,Drolet,Maldives,burlywood
 2,Shelly,Yemen,plum
 3,Tuck,Mayotte,antiquewhite


### PR DESCRIPTION
I got errors below when trying [4.10. JSON](https://github.com/noborus/trdsql#410-json) sample in `README.md`.

```
$ cat sample2.json
[
    {
      "id": 1,
      "name": "Drolet",
      "attribute": { "country": "Maldives", "color": "burlywood" }
    },
    {
      "id": 2,
      "name": "Shelly",
      "attribute": { "country": "Yemen", "color": "plum" }
    },
    {
      "id": 3,
      "name": "Tuck",
      "attribute": { "country": "Mayotte", "color": "antiquewhite" }
    }
]

$ trdsql -ijson "SELECT id, name, JSON_EXTRACT(attribute,'$country'), JSON_EXTRACT(attribute,'$color') FROM sample2.json"
```

Using SQLite3 driver:
```
2022/11/19 07:04:22 export: JSON path error near ''
```

Using MySQL driver:
```
2022/11/19 07:04:46 export: Error 3143 (42000): Invalid JSON path expression. The error is around character position 0.
```

The correct SQL is probably here.
```
$ trdsql -ijson "SELECT id, name, JSON_EXTRACT(attribute,'$.country'), JSON_EXTRACT(attribute,'$.color') FROM sample2.json"
1,Drolet,Maldives,burlywood
2,Shelly,Yemen,plum
3,Tuck,Mayotte,antiquewhite
```

Version:
```
$ trdsql --version
trdsql version v0.10.1
```
