### PR TITLE
Preventing panic due to invalid yaml file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        exclude:
+          - go-version: "1.19"
+            platform: windows-latest
   dbtest:
     runs-on: ubuntu-latest
     services:

--- a/input_yaml.go
+++ b/input_yaml.go
@@ -79,7 +79,7 @@ func (r *YAMLReader) yamlParse(opts *ReadOpts) error {
 	for i := 0; i < opts.InPreRead; i++ {
 		if err := r.wrapDecode(&top); err != nil {
 			if !errors.Is(err, io.EOF) {
-				return fmt.Errorf("%w: %w", ErrInvalidYAML, err)
+				return fmt.Errorf("%w: %s", ErrInvalidYAML, err)
 			}
 			debug.Printf(err.Error())
 			return nil


### PR DESCRIPTION
Prevents panic, but just displays an error instead of panic. This is for issue https://github.com/goccy/go-yaml/issues/373, so it may be removed if go-yaml is updated.