### PR TITLE
Fixed INSERT failure when there are many columns

### DIFF
--- a/database.go
+++ b/database.go
@@ -204,7 +204,11 @@ func (db *DB) insertImport(ctx context.Context, table *importTable, reader Reade
 	var stmt *sql.Stmt
 	defer db.stmtClose(stmt)
 
-	table.maxCap = (db.maxBulk / len(table.row)) * len(table.row)
+	if len(table.row) > db.maxBulk {
+		table.maxCap = len(table.row)
+	} else {
+		table.maxCap = (db.maxBulk / len(table.row)) * len(table.row)
+	}
 	bulk := make([]interface{}, 0, table.maxCap)
 
 	preRows := reader.PreReadRow()

--- a/database_connect.go
+++ b/database_connect.go
@@ -37,7 +37,7 @@ func Connect(driver, dsn string) (*DB, error) {
 	switch driver {
 	case "sqlite3", "sqlite3_ext", "sqlite":
 		db.quote = "`"
-		db.maxBulk = 500
+		db.maxBulk = 1000
 	case "mysql":
 		db.quote = "`"
 		db.maxBulk = 1000

--- a/database_connect_cgo.go
+++ b/database_connect_cgo.go
@@ -45,7 +45,7 @@ func Connect(driver, dsn string) (*DB, error) {
 	switch driver {
 	case "sqlite3", "sqlite3_ext", "sqlite":
 		db.quote = "`"
-		db.maxBulk = 500
+		db.maxBulk = 10000
 	case "mysql":
 		db.quote = "`"
 		db.maxBulk = 1000


### PR DESCRIPTION
Fixed INSERT failure when number of columns is greater than maxBulk. Increased maxBulk to 1000.