### PR TITLE
Fixed automatic determination of TSV/PSV

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -41,10 +41,10 @@ var readerFuncs = map[Format]ReaderFunc{
 		return NewTBLNReader(reader, opts)
 	},
 	TSV: func(reader io.Reader, opts *ReadOpts) (Reader, error) {
-		return NewCSVReader(reader, opts)
+		return NewTSVReader(reader, opts)
 	},
 	PSV: func(reader io.Reader, opts *ReadOpts) (Reader, error) {
-		return NewCSVReader(reader, opts)
+		return NewPSVReader(reader, opts)
 	},
 	WIDTH: func(reader io.Reader, opts *ReadOpts) (Reader, error) {
 		return NewGWReader(reader, opts)


### PR DESCRIPTION
The delimiter was not automatically set for TSV/PSV (it worked only when the delimiter was specified).