### PR TITLE
Fixed a typo in examples

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -372,7 +372,7 @@ func Usage(flags *flag.FlagSet) {
 	fmt.Fprintf(flags.Output(), "\n%s\n", bold("Examples:"))
 	fmt.Fprintf(flags.Output(), "  $ trdsql \"SELECT c1,c2 FROM test.csv\"\n")
 	fmt.Fprintf(flags.Output(), "  $ trdsql -oltsv \"SELECT c1,c2 FROM test.json::.items\"\n")
-	fmt.Fprintf(flags.Output(), "  $ cat test.csv | trdsql -i csv -oltsv \"SELECT c1,c2 FROM -\"\n")
+	fmt.Fprintf(flags.Output(), "  $ cat test.csv | trdsql -icsv -oltsv \"SELECT c1,c2 FROM -\"\n")
 }
 
 func usageFlag(f *flag.Flag) string {


### PR DESCRIPTION
This typo was noticed by Stuart Henderson

See: https://marc.info/?l=openbsd-ports&m=171992964702902&w=2