### PR TITLE
fix: use debug.Printf("%s", ...) for all debug output

### DIFF
--- a/database.go
+++ b/database.go
@@ -63,7 +63,7 @@ func (db *DB) CreateTable(ctx context.Context, tableName string, columnNames []s
 	}
 
 	query := db.queryCreateTable(tableName, columnNames, columnTypes, isTemporary)
-	debug.Printf(query)
+	debug.Printf("%s", query)
 	_, err := db.Tx.ExecContext(ctx, query)
 	return err
 }
@@ -132,7 +132,7 @@ func (db *DB) Import(ctx context.Context, tableName string, columnNames []string
 // copyImport adds rows to a table with the COPY clause (PostgreSQL only).
 func (db *DB) copyImport(ctx context.Context, table *importTable, reader Reader) error {
 	query := queryCopy(table)
-	debug.Printf(query)
+	debug.Printf("%s", query)
 
 	stmt, err := db.Tx.PrepareContext(ctx, query)
 	if err != nil {
@@ -288,7 +288,7 @@ func (db *DB) bulkStmtOpen(ctx context.Context, table *importTable, stmt *sql.St
 
 func (db *DB) insertPrepare(ctx context.Context, table *importTable) (*sql.Stmt, error) {
 	query := queryInsert(table)
-	debug.Printf(query)
+	debug.Printf("%s", query)
 
 	stmt, err := db.Tx.PrepareContext(ctx, query)
 	if err != nil {

--- a/exporter.go
+++ b/exporter.go
@@ -57,7 +57,7 @@ func (e *WriteFormat) export(ctx context.Context, db *DB, query string) error {
 	if query == "" {
 		return ErrNoStatement
 	}
-	debug.Printf(query)
+	debug.Printf("%s", query)
 
 	if db.isExec(query) {
 		return db.OtherExec(ctx, query)

--- a/input_csv.go
+++ b/input_csv.go
@@ -73,7 +73,7 @@ func NewCSVReader(reader io.Reader, opts *ReadOpts) (*CSVReader, error) {
 				return r, err
 			}
 			r.setColumnType()
-			debug.Printf(err.Error())
+			debug.Printf("%s", err.Error())
 			return r, nil
 		}
 		rows := make([]string, len(row))

--- a/input_json.go
+++ b/input_json.go
@@ -57,7 +57,7 @@ func NewJSONReader(reader io.Reader, opts *ReadOpts) (*JSONReader, error) {
 			if !errors.Is(err, io.EOF) {
 				return r, fmt.Errorf("%w: %s", ErrInvalidJSON, err)
 			}
-			debug.Printf(err.Error())
+			debug.Printf("%s", err.Error())
 			return r, nil
 		}
 

--- a/input_ltsv.go
+++ b/input_ltsv.go
@@ -43,7 +43,7 @@ func NewLTSVReader(reader io.Reader, opts *ReadOpts) (*LTSVReader, error) {
 				return r, err
 			}
 			r.setColumnType()
-			debug.Printf(err.Error())
+			debug.Printf("%s", err.Error())
 			return r, nil
 		}
 

--- a/input_tbln.go
+++ b/input_tbln.go
@@ -32,7 +32,7 @@ func NewTBLNReader(reader io.Reader, opts *ReadOpts) (*TBLNRead, error) {
 		if !errors.Is(err, io.EOF) {
 			return r, err
 		}
-		debug.Printf(err.Error())
+		debug.Printf("%s", err.Error())
 		return r, nil
 	}
 
@@ -70,7 +70,7 @@ func NewTBLNReader(reader io.Reader, opts *ReadOpts) (*TBLNRead, error) {
 			if !errors.Is(err, io.EOF) {
 				return r, err
 			}
-			debug.Printf(err.Error())
+			debug.Printf("%s", err.Error())
 			return r, nil
 		}
 		r.preRead = append(r.preRead, r.recToRow(rec))

--- a/input_yaml.go
+++ b/input_yaml.go
@@ -71,7 +71,7 @@ func (r *YAMLReader) yamlParse(opts *ReadOpts) error {
 			if !errors.Is(err, io.EOF) {
 				return fmt.Errorf("%w: %s", ErrInvalidYAML, err)
 			}
-			debug.Printf(err.Error())
+			debug.Printf("%s", err.Error())
 			return nil
 		}
 


### PR DESCRIPTION
- Replace debug.Printf(query) with debug.Printf("%s", query)
- Replace debug.Printf(err.Error()) with debug.Printf("%s", err.Error())
- Ensures consistent and safe debug output formatting