### PR TITLE
remove: drop nowrap option after migrating from tablewriter to termhyo

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ Or, [guess the output format by file name](#Guessbyoutputfilename).
 * `-oq` **character** quote character for output. (default "\"")(CSV only).
 * `-oaq` enclose all fields in quotes for output(CSV only).
 * `-ocrlf` use CRLF for output. End each output line with '\\r\\n' instead of '\\n'."(CSV only).
-* `-onowrap` do not wrap long columns(AT and MD only).
 * `-onull` value(string) to convert from null on output.
 * `-oz` **string** compression format for output. [ gzip | bz2 | zstd | lz4 | xz ]
 
@@ -842,8 +841,6 @@ $ trdsql -omd "SELECT * FROM test.csv"
 |  2 | Melon  |
 |  3 | Apple  |
 ```
-
-The `-onowrap` option does not wrap long columns in `at` or `md` output.
 
 ###  4.17. <a name='vertical-format-output'></a>Vertical format output
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,6 @@ var (
 	outAllQuotes    bool
 	outUseCRLF      bool
 	outHeader       bool
-	outNoWrap       bool
 	outNoAlign      bool
 	outNull         nilString
 )
@@ -231,7 +230,6 @@ func run(writer io.Writer, cfg *dbConfig, args []string) error {
 		trdsql.OutAllQuotes(outAllQuotes),
 		trdsql.OutUseCRLF(outUseCRLF),
 		trdsql.OutHeader(outHeader),
-		trdsql.OutNoWrap(outNoWrap),
 		trdsql.OutNeedNULL(outNull.valid),
 		trdsql.OutNULL(outNull.str),
 		trdsql.OutNoAlign(outNoAlign),
@@ -375,7 +373,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&outQuote, "out-quote", "\"", "quote character for output.")
 	rootCmd.PersistentFlags().BoolVar(&outAllQuotes, "out-all-quotes", false, "enclose all fields in quotes for output.")
 	rootCmd.PersistentFlags().BoolVar(&outUseCRLF, "out-crlf", false, "use CRLF for output. End each output line with '\\r\\n' instead of '\\n'.")
-	rootCmd.PersistentFlags().BoolVar(&outNoWrap, "out-nowrap", false, "do not wrap long lines(at/md only).")
 	rootCmd.PersistentFlags().BoolVar(&outHeader, "out-header", false, "output column name as header.")
 	rootCmd.PersistentFlags().BoolVar(&outNoAlign, "out-no-align", false, "do not align(at/md only).")
 	rootCmd.PersistentFlags().StringVar(&outCompression, "out-compression", "", "output compression format. [gz|bz2|zstd|lz4|xz]")

--- a/writer.go
+++ b/writer.go
@@ -53,8 +53,6 @@ type WriteOpts struct {
 	OutUseCRLF bool
 	// OutHeader is true if it outputs a header(Use only CSV and Raw).
 	OutHeader bool
-	// OutNoWrap is true, do not wrap long columns(Use only AT and MD).
-	OutNoWrap bool
 	// OutNeedNULL is true, replace NULL with OutNULL.
 	OutNeedNULL bool
 	// OutJSONToYAML is true, convert JSON to YAML(Use only YAML).
@@ -105,13 +103,6 @@ func OutAllQuotes(a bool) WriteOpt {
 func OutHeader(h bool) WriteOpt {
 	return func(args *WriteOpts) {
 		args.OutHeader = h
-	}
-}
-
-// OutNoWrap sets flag to output do not wrap long columns.
-func OutNoWrap(w bool) WriteOpt {
-	return func(args *WriteOpts) {
-		args.OutNoWrap = w
 	}
 }
 


### PR DESCRIPTION
- Remove -onowrap / --out-nowrap option from CLI and documentation
- Remove related code and WriteOpts fields
- termhyo does no wrapping, so this option is removed